### PR TITLE
support "max" options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # textlint-rule-max-ten [![Build Status](https://travis-ci.org/azu/textlint-rule-max-ten.svg?branch=master)](https://travis-ci.org/azu/textlint-rule-max-ten)
 
-[textlint](https://github.com/azu/textlint "textlint") rule is that limit maxinum ten(、) count of sentence.
+[textlint](https://github.com/azu/textlint "textlint") rule is that limit maximum ten(、) count of sentence.
 
 ## Installation
 
@@ -11,6 +11,22 @@
     $ npm install textlint textlint-rule-max-ten
     $ textlint --rule max-ten README.md
     #    11:0  error  一つの文で"、"を3つ以上使用しています  max-ten
+
+## Configure
+
+Configure the maximum number of "、" allowed in a sentence. The default is `3`
+
+Configure `"max"` value of the `.textlintrc` file.
+
+```json
+{
+  "rules": {
+    "max-ten": {
+        "max" : 3
+    }
+  }
+}
+```
 
 ## Tests
 

--- a/src/max-ten.js
+++ b/src/max-ten.js
@@ -1,14 +1,17 @@
 // LICENSE : MIT
 "use strict";
 import {RuleHelper} from "textlint-rule-helper"
+
+const defaultOptions = {max: 3};
 function countTen(text) {
     return text.split("、").length - 1;
 }
 /**
  * @param {RuleContext} context
+ * @param {object} options
  */
-export default function (context) {
-    var maxLen = 3;
+export default function (context, options = defaultOptions) {
+    var maxLen = options.max;
     const punctuation = /[。.]/;
     let helper = new RuleHelper(context);
     let {Syntax, RuleError, report, getSource} = context;

--- a/test/max-ten-test.js
+++ b/test/max-ten-test.js
@@ -2,26 +2,60 @@ import {textlint} from "textlint"
 import rule from "../src/max-ten"
 import path from "path"
 import assert from "power-assert"
+function textIncludeTen(count) {
+    return (new Array(count)).join("テスト、") + "です";
+}
 describe("max-ten", function () {
-    beforeEach(function () {
-        textlint.setupRules({
-            "max-ten": rule
-        });
-    });
     afterEach(function () {
         textlint.resetRules();
     });
-    it("should report error", function () {
-        var filePath = path.join(__dirname, "/fixtures/error.md");
-        var result = textlint.lintFile(filePath);
-        assert(result.filePath === filePath);
-        assert(result.messages.length > 0);
-        assert.equal(result.messages[0].ruleId, "max-ten");
+    context("when use default option", function () {
+        beforeEach(function () {
+            textlint.setupRules({
+                "max-ten": rule
+            });
+        });
+        it("should report error", function () {
+            var filePath = path.join(__dirname, "/fixtures/error.md");
+            var result = textlint.lintFile(filePath);
+            assert(result.filePath === filePath);
+            assert(result.messages.length > 0);
+            assert.equal(result.messages[0].ruleId, "max-ten");
+        });
+        it("should not report error", function () {
+            var filePath = path.join(__dirname, "/fixtures/pass.md");
+            var result = textlint.lintFile(filePath);
+            assert(result.filePath === filePath);
+            assert(result.messages.length === 0);
+        });
     });
-    it("should not report error", function () {
-        var filePath = path.join(__dirname, "/fixtures/pass.md");
-        var result = textlint.lintFile(filePath);
-        assert(result.filePath === filePath);
-        assert(result.messages.length === 0);
+    context("Change options#maxLen", function () {
+        context("when maxLen is 5, count of `、` < 5", function () {
+            it("should not report error", ()=> {
+                textlint.setupRules({
+                    "max-ten": rule
+                }, {
+                    "max-ten": {
+                        "max": 5
+                    }
+                });
+                var result = textlint.lintMarkdown("a、b、c、d、です。");
+                console.log(result.messages);
+                assert(result.messages.length === 0);
+            });
+        });
+        context("when maxLen is 5, count of `、` >= 5", function () {
+            it("should report error", ()=> {
+                textlint.setupRules({
+                    "max-ten": rule
+                }, {
+                    "max-ten": {
+                        "max": 5
+                    }
+                });
+                var result = textlint.lintMarkdown("a、b、c、d、e、です。");
+                assert(result.messages.length > 0);
+            });
+        });
     });
 });


### PR DESCRIPTION
Support `"max"` options.

It configure the maximum number of "、" in a sentence.
The default is `3`