### PR TITLE
Fix position to report in a certain cases

### DIFF
--- a/src/max-ten.js
+++ b/src/max-ten.js
@@ -20,6 +20,20 @@ function isSandwichedMeishi({
     return before.pos === "名詞" && after.pos === "名詞";
 }
 /**
+ * add two positions.
+ * note: line starts with 1, column starts with 0.
+ * @param {Position} base
+ * @param {Position} relative
+ * @return {Position}
+ */
+function addPositions(base, relative) {
+    return {
+        line: base.line + relative.line - 1, // line 1 + line 1 should be line 1
+        column: relative.line == 1 ? base.column + relative.column // when the same line
+                                   : relative.column               // when another line
+    };
+}
+/**
  * @param {RuleContext} context
  * @param {object} options
  */
@@ -78,10 +92,11 @@ export default function (context, options = {}) {
                         }
                         // report
                         if (currentTenCount >= maxLen) {
-                            let position = source.indexToPosition(lastToken.word_position - 1);
+                            let positionInSentence = source.indexToPosition(lastToken.word_position - 1);
+                            let positionInNode = addPositions(sentence.loc.start, positionInSentence);
                             let ruleError = new context.RuleError(`一つの文で"、"を${maxLen}つ以上使用しています`, {
-                                line: position.line - 1,
-                                column: position.column
+                                line: positionInNode.line - 1,
+                                column: positionInNode.column
                             });
                             report(node, ruleError);
                             currentTenCount = 0;

--- a/test/max-ten-test.js
+++ b/test/max-ten-test.js
@@ -74,6 +74,32 @@ tester.run("max-ten", rule, {
                     column: 26
                 }
             ]
+        },
+        {
+            text: `複数のセンテンスがある場合。これでも、columnが、ちゃんと計算、されているはずです。`,
+            options: {
+                "max": 3
+            },
+            errors: [
+                {
+                    message: `一つの文で"、"を3つ以上使用しています`,
+                    line: 1,
+                    column: 34
+                }
+            ]
+        },
+        {
+            text: `複数のセンテンスがあって、改行されている場合でも\n大丈夫です。これでも、lineとcolumnが、ちゃんと計算、されているはずです。`,
+            options: {
+                "max": 3
+            },
+            errors: [
+                {
+                    message: `一つの文で"、"を3つ以上使用しています`,
+                    line: 2,
+                    column: 31
+                }
+            ]
         }
     ]
 });


### PR DESCRIPTION
## Problem

When the second or later sentence in the paragraph contains many tens, the rule reports wrong position in some cases.

```
$ cat problematic_cases.md
複数のセンテンスがある場合。これでも、columnが、ちゃんと計算、されているはずです。

複数のセンテンスがあって、改行されている場合でも
大丈夫です。これでも、lineとcolumnが、ちゃんと計算、されているはずです。
```

## Before

Reports wrong position.

```
$ textlint --rule max-ten problematic_cases.md

/private/tmp/problematic_cases.md
  1:20  error  一つの文で"、"を3つ以上使用しています  max-ten
  3:25  error  一つの文で"、"を3つ以上使用しています  max-ten

✖ 2 problems (2 errors, 0 warnings)

```

## After

Reports correct position.

```
$ textlint --rule max-ten problematic_cases.md

/private/tmp/problematic_cases.md
  1:34  error  一つの文で"、"を3つ以上使用しています  max-ten
  4:31  error  一つの文で"、"を3つ以上使用しています  max-ten

✖ 2 problems (2 errors, 0 warnings)

```